### PR TITLE
fix: 修改公众号文章里面的es规范的脚本不执行的问题

### DIFF
--- a/App.vue
+++ b/App.vue
@@ -1,14 +1,13 @@
 <script>
 	export default {
 		onLaunch: function() {
-			console.warn('当前组件仅支持 uni_modules 目录结构 ，请升级 HBuilderX 到 3.1.0 版本以上！')
-			console.log('App Launch')
+
 		},
 		onShow: function() {
-			console.log('App Show')
+
 		},
 		onHide: function() {
-			console.log('App Hide')
+
 		}
 	}
 </script>


### PR DESCRIPTION
有个别文章比如
https://mp.weixin.qq.com/s?__biz=MzIzNjc1NzUzMw==&mid=2247683252&idx=5&sn=01ca184ca949279c3fa868c650827d8c&chksm=e8debbc6dfa932d08e39f46df20e8cc0fd0c9bf79d59ae41a054fe9cc13c981948eac656e1aa#rd
需要执行html里面的脚本文件才能正常展示